### PR TITLE
Update: On / Off 애니메이션 별도로 적용 가능하게 변경

### DIFF
--- a/Packages/kr.needon.modular-auto-toggle/Runtime/ToggleItemEditor.cs
+++ b/Packages/kr.needon.modular-auto-toggle/Runtime/ToggleItemEditor.cs
@@ -222,7 +222,7 @@ namespace Runtime
                         }
 
                         // 초기화된 애니메이션 클립에서 블렌드 쉐이프 값을 제거합니다.
-                        if (!_applyToOnAnimation && onToggleExists)
+                        /* if (!_applyToOnAnimation && onToggleExists)
                         {
                             AnimationClip onClipToClear =
                                 AssetDatabase.LoadAssetAtPath<AnimationClip>(onToggleAnimePath);
@@ -234,7 +234,7 @@ namespace Runtime
                             AnimationClip offClipToClear =
                                 AssetDatabase.LoadAssetAtPath<AnimationClip>(offToggleAnimePath);
                             clearAllBlendShapeAnimations(offClipToClear, toggleItem);
-                        }
+                        }*/
                     }
                 }
             }


### PR DESCRIPTION
선택하지 않은 애니메이션을 초기화하게 해버리면 On/Off에서 블랜드쉐이프가 달라져야 하는 경우 반대 쪽 애니메이션이 초기화되버려서 동작하지 않습니다.

Write Default가 있으면 둘 중 하나만 설정해도 되기는 하지만, 보다 세밀한 제어를 위해서는 두 애니메이션 모두 선택적으로 동작하는것이 좋을 것 같습니다.